### PR TITLE
fixed wrong link to JIRA issues page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
   </scm>
   <issueManagement>
     <system>jira</system>
-    <url>http://jira.xwiki.org/jira/browse/NPMIG</url>
+    <url>http://jira.xwiki.org/browse/NPMIG</url>
   </issueManagement>
   <modules>
     <!-- Sorted Alphabetically -->


### PR DESCRIPTION
Fixed link to http://jira.xwiki.org/browse/NPMIG (which in itself is a redirect to https://jira.xwiki.org/projects/NPMIG/issues, so either one of those would be better than the current 404.