### PR TITLE
NPMIG-67: Running the migrator on pages that have a non-existent author will make the document listeners that check for the authorization behave unexpectedly.

### DIFF
--- a/application-nestedpagesmigrator-api/pom.xml
+++ b/application-nestedpagesmigrator-api/pom.xml
@@ -30,7 +30,7 @@
   <description>Nested Pages Migrator - API</description>
   <properties>
     <!-- Test coverage -->
-    <xwiki.jacoco.instructionRatio>0.73</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.74</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Nested Pages Migrator API</xwiki.extension.name>
     <!--FIXME-->

--- a/application-nestedpagesmigrator-api/pom.xml
+++ b/application-nestedpagesmigrator-api/pom.xml
@@ -30,7 +30,7 @@
   <description>Nested Pages Migrator - API</description>
   <properties>
     <!-- Test coverage -->
-    <xwiki.jacoco.instructionRatio>0.74</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.73</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Nested Pages Migrator API</xwiki.extension.name>
     <!--FIXME-->
@@ -86,4 +86,28 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <analysisConfiguration><![CDATA[
+            {
+              "revapi": {
+                "ignore" : [
+                  {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method void org.xwiki.contrib.nestedpagesmigrator.MigrationConfiguration::<init>(org.xwiki.model.reference.WikiReference)",
+                    "new": "method void org.xwiki.contrib.nestedpagesmigrator.MigrationConfiguration::<init>(org.xwiki.model.reference.WikiReference, org.xwiki.model.reference.DocumentReference)",
+                    "justification": "The Renaming Actions should be executed with the current user as the author rather than the author of the document."
+                  }
+                ]
+              }
+            }
+          ]]></analysisConfiguration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/MigrationConfiguration.java
+++ b/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/MigrationConfiguration.java
@@ -36,32 +36,36 @@ import org.xwiki.model.reference.WikiReference;
 public class MigrationConfiguration implements Serializable
 {
     private boolean excludeHiddenPages;
-    
+
     private boolean excludeClassPages;
-    
+
     private boolean dontMoveChildren;
-    
+
     private boolean addAutoRedirect;
 
     private boolean convertPreferences;
 
     private boolean convertRights;
-    
+
     private List<SpaceReference> excludedSpaces = new ArrayList<>();
-    
+
     private List<SpaceReference> includedSpaces = new ArrayList<>();
 
     private List<DocumentReference> excludedObjectClasses = new ArrayList<>();
 
     private List<DocumentReference> excludedPages = new ArrayList<>();
-    
+
     private WikiReference wikiReference;
+
+    private DocumentReference userReference;
 
     /**
      * Create a new configuration.
-     * @param wikiReference the reference of the wiki where the migration will occur
+     *
+     * @param wikiReference the reference of the wiki where the migration will occur.
+     * @param userReference the reference of the user that starts the migration.
      */
-    public MigrationConfiguration(WikiReference wikiReference)
+    public MigrationConfiguration(WikiReference wikiReference, DocumentReference userReference)
     {
         excludeHiddenPages = true;
         excludeClassPages = true;
@@ -70,6 +74,7 @@ public class MigrationConfiguration implements Serializable
         convertPreferences = true;
         convertRights = false;
         this.wikiReference = wikiReference;
+        this.userReference = userReference;
     }
 
     /**
@@ -137,8 +142,8 @@ public class MigrationConfiguration implements Serializable
     }
 
     /**
-     * @param dontMoveChildren if the migration should not move the pages under their parents but only transform them to
-     * nested pages.
+     * @param dontMoveChildren if the migration should not move the pages under their parents but only transform
+     *     them to nested pages.
      */
     public void setDontMoveChildren(boolean dontMoveChildren)
     {
@@ -154,7 +159,7 @@ public class MigrationConfiguration implements Serializable
     }
 
     /**
-     *  @param convertPreferences if the preferences must be converted
+     * @param convertPreferences if the preferences must be converted
      */
     public void setConvertPreferences(boolean convertPreferences)
     {
@@ -206,7 +211,7 @@ public class MigrationConfiguration implements Serializable
     {
         excludedSpaces.addAll(spaceReferences);
     }
-    
+
     public void addIncludedSpace(SpaceReference spaceReference)
     {
         includedSpaces.add(spaceReference);
@@ -245,6 +250,11 @@ public class MigrationConfiguration implements Serializable
     public void setWikiReference(WikiReference wikiReference)
     {
         this.wikiReference = wikiReference;
+    }
+
+    public DocumentReference getUserReference()
+    {
+        return userReference;
     }
 
     public boolean isAddAutoRedirect()

--- a/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/internal/executor/MigrationPlanExecutor.java
+++ b/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/internal/executor/MigrationPlanExecutor.java
@@ -240,7 +240,7 @@ public class MigrationPlanExecutor
      */
     private void moveDocument(MigrationAction action) throws Exception
     {
-        DocumentReference author = getDocumentAuthor(action.getSourceDocument())    ;
+        DocumentReference author = this.configuration.getUserReference();
 
         // Rename the document
         renameJobExecutor.rename(action.getSourceDocument(), action.getTargetDocument(), author, configuration);

--- a/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/internal/executor/MigrationPlanExecutor.java
+++ b/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/internal/executor/MigrationPlanExecutor.java
@@ -262,14 +262,6 @@ public class MigrationPlanExecutor
         }
     }
 
-    private DocumentReference getDocumentAuthor(DocumentReference documentReference) throws XWikiException
-    {
-        XWikiContext context = contextProvider.get();
-        XWiki xwiki = context.getWiki();
-        XWikiDocument doc = xwiki.getDocument(documentReference, context);
-        return doc.getAuthorReference();
-    }
-
     /**
      * Apply the preferences of the given action on the given document.
      *

--- a/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/script/NestedPagesMigratorScriptService.java
+++ b/application-nestedpagesmigrator-api/src/main/java/org/xwiki/contrib/nestedpagesmigrator/script/NestedPagesMigratorScriptService.java
@@ -114,7 +114,7 @@ public class NestedPagesMigratorScriptService implements ScriptService
      */
     public MigrationConfiguration newMigrationConfiguration(String wikiId)
     {
-        return new MigrationConfiguration(new WikiReference(wikiId));
+        return new MigrationConfiguration(new WikiReference(wikiId), documentAccessBridge.getCurrentUserReference());
     }
 
     /**

--- a/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/MigrationPlanExecutorTest.java
+++ b/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/MigrationPlanExecutorTest.java
@@ -78,6 +78,8 @@ public class MigrationPlanExecutorTest
     private XWiki xwiki;
     private Job job;
 
+    private final DocumentReference adminRef = new DocumentReference("someWiki", "XWiki", "Admin");
+
     @Before
     public void setUp() throws Exception
     {
@@ -202,7 +204,7 @@ public class MigrationPlanExecutorTest
                 eq(true), eq(context))).thenReturn(objTitanic3DPreferences);
 
         // Configuration
-        MigrationConfiguration configuration = new MigrationConfiguration(new WikiReference("xwiki"));
+        MigrationConfiguration configuration = new MigrationConfiguration(new WikiReference("xwiki"), this.adminRef);
         // Test
         mocker.getComponentUnderTest().performMigration(plan, configuration);
 
@@ -280,7 +282,8 @@ public class MigrationPlanExecutorTest
                 eq(context))).thenThrow(e);
 
         // Test
-        mocker.getComponentUnderTest().performMigration(plan, new MigrationConfiguration(new WikiReference("xwiki")));
+        mocker.getComponentUnderTest()
+            .performMigration(plan, new MigrationConfiguration(new WikiReference("xwiki"),this.adminRef));
 
         // Verify
         verify(progressManager).pushLevelProgress(eq(1), any(MigrationPlanExecutor.class));

--- a/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/PagesMigrationPlanCreatorTest.java
+++ b/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/PagesMigrationPlanCreatorTest.java
@@ -65,6 +65,8 @@ public class PagesMigrationPlanCreatorTest
     private XWikiContext context;
     private XWiki xwiki;
     private PagesToTransformGetter pagesToTransformGetter;
+
+    private final DocumentReference adminRef = new DocumentReference("someWiki", "XWiki", "Admin");
     
     private void assertNotEquals(MigrationPlanTree plan, Object o1, Object o2) throws Exception
     {
@@ -162,7 +164,8 @@ public class PagesMigrationPlanCreatorTest
         Example example = new Example(exampleName);
         setUpExample(example);
 
-        MigrationConfiguration migrationConfiguration = new MigrationConfiguration(new WikiReference("xwiki"));
+        MigrationConfiguration migrationConfiguration =
+            new MigrationConfiguration(new WikiReference("xwiki"),this.adminRef);
         migrationConfiguration.setDontMoveChildren(example.isDontMoveChildrenEnabled());
 
         when(pagesToTransformGetter.getPagesToConvert(any(MigrationConfiguration.class)))

--- a/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/PreferencesMigrationPlanCreatorTest.java
+++ b/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/PreferencesMigrationPlanCreatorTest.java
@@ -58,7 +58,9 @@ public class PreferencesMigrationPlanCreatorTest
     private PreferencesPropertiesGetter preferencesPropertiesGetter;
     private DocumentAccessBridge documentAccessBridge;
     private JobProgressManager progressManager;
-    
+
+    private final DocumentReference adminRef = new DocumentReference("someWiki", "XWiki", "Admin");
+
     @Before
     public void setUp() throws Exception
     {
@@ -145,7 +147,7 @@ public class PreferencesMigrationPlanCreatorTest
 
         // Run the component
         mocker.getComponentUnderTest().convertPreferences(plan,
-                new MigrationConfiguration(new WikiReference("xwiki")));
+                new MigrationConfiguration(new WikiReference("xwiki"), this.adminRef));
 
         // Verify
         verifyPreferences(example, plan);

--- a/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/TerminalPagesGetterTest.java
+++ b/application-nestedpagesmigrator-api/src/test/java/org/xwiki/contrib/nestedpagesmigrator/internal/TerminalPagesGetterTest.java
@@ -78,6 +78,8 @@ public class TerminalPagesGetterTest
     private QueryFilter uniqueFilter;
     private QueryFilter hiddenFilter;
 
+    private final DocumentReference adminRef = new DocumentReference("someWiki", "XWiki", "Admin");
+
     @Before
     public void setUp() throws Exception
     {
@@ -164,7 +166,7 @@ public class TerminalPagesGetterTest
 
 
         // Test
-        MigrationConfiguration configuration = new MigrationConfiguration(wikiReference);
+        MigrationConfiguration configuration = new MigrationConfiguration(wikiReference, this.adminRef);
         configuration.addExcludedPage(new DocumentReference("someWiki", "someSpace", "excludeMe"));
         configuration.addExcludedSpace(new SpaceReference("someWiki", "excludeMe"));
         configuration.addExcludedObjectClass(new DocumentReference("someWiki", "someSpace", "excludeClass"));
@@ -195,7 +197,8 @@ public class TerminalPagesGetterTest
         // Test
         MigrationException caughtException = null;
         try {
-            mocker.getComponentUnderTest().getPagesToConvert(new MigrationConfiguration(new WikiReference("someWiki")));
+            mocker.getComponentUnderTest()
+                .getPagesToConvert(new MigrationConfiguration(new WikiReference("someWiki"), this.adminRef));
         } catch (MigrationException e) {
             caughtException = e;
         }
@@ -227,7 +230,7 @@ public class TerminalPagesGetterTest
         when(rd1.getParentReference()).thenReturn(new DocumentReference("xwiki", "Main", "WebHome"));
 
         // Test
-        MigrationConfiguration configuration = new MigrationConfiguration(wikiReference);
+        MigrationConfiguration configuration = new MigrationConfiguration(wikiReference, this.adminRef);
         configuration.setExcludeHiddenPages(false);
         configuration.setDontMoveChildren(true);
         configuration.setExcludeClassPages(false);


### PR DESCRIPTION
https://jira.xwiki.org/browse/NPMIG-67

This PR aims to use the user running the migration as the author for the Moving/Renaming of the documents.

![image](https://user-images.githubusercontent.com/45433221/225648581-ca9314c6-75ad-467d-bc0e-8b6f4ef5ec1f.png)
